### PR TITLE
Add Costco receipt parser with taxable status support

### DIFF
--- a/app/components/GroceryParser.tsx
+++ b/app/components/GroceryParser.tsx
@@ -95,6 +95,7 @@ export default function GroceryParser({ onParseComplete }: GroceryParserProps) {
           >
             <option value="walmart">Walmart</option>
             <option value="kroger">Kroger</option>
+            <option value="costco">Costco</option>
             <option value="target">Target</option>
           </select>
         </div>


### PR DESCRIPTION
## Summary
- Add Costco receipt parser that handles the unique Costco format
- Parse item codes, names, prices, and discount lines
- Automatically determine taxable status based on E prefix (E = tax-exempt)
- Strip decorative `**` wrapper from item names

## Test plan
- [ ] Parse a Costco receipt with items that have and don't have E prefix
- [ ] Verify discounts are correctly applied to parent items
- [ ] Confirm taxable status is saved correctly for new items
- [ ] Test that existing item taxable status is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)