### PR TITLE
Save original pasted text with receipts

### DIFF
--- a/app/api/parse/route.ts
+++ b/app/api/parse/route.ts
@@ -485,8 +485,8 @@ export async function POST(request: NextRequest) {
 
     const userDb = new UserDatabase(env.DB, user.id);
 
-    // Create a new receipt
-    const receiptResult = await userDb.createReceipt(source);
+    // Create a new receipt with original text for future parser improvements
+    const receiptResult = await userDb.createReceipt(source, undefined, text);
     const receiptId = Number(receiptResult.meta.last_row_id);
 
     // Process each item

--- a/lib/d1-db.ts
+++ b/lib/d1-db.ts
@@ -103,10 +103,10 @@ export class UserDatabase {
   }
 
   // Receipts
-  async createReceipt(source: string, date?: string) {
+  async createReceipt(source: string, date?: string, originalText?: string) {
     return await this.db
-      .prepare("INSERT INTO receipts (user_id, source, date) VALUES (?, ?, ?)")
-      .bind(this.userId, source, date || new Date().toISOString())
+      .prepare("INSERT INTO receipts (user_id, source, date, original_text) VALUES (?, ?, ?, ?)")
+      .bind(this.userId, source, date || new Date().toISOString(), originalText || null)
       .run();
   }
 

--- a/migrations/0002_add_original_text.sql
+++ b/migrations/0002_add_original_text.sql
@@ -1,0 +1,3 @@
+-- Add original_text column to receipts table
+-- Stores the raw pasted text for parser improvement and debugging
+ALTER TABLE receipts ADD COLUMN original_text TEXT;


### PR DESCRIPTION
## Summary
- Add `original_text` column to receipts table via new migration
- Update `createReceipt()` to accept and store the raw pasted text
- Pass original text from parse route when creating receipts

This enables future improvements like parser debugging, auto-categorization training, and receipt reconstruction.

## Test plan
- [x] Migration applied locally
- [x] Migration applied to production
- [x] Deployed to Cloudflare Pages

🤖 Generated with [Claude Code](https://claude.ai/code)